### PR TITLE
add edge case for orderId

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -128,7 +128,7 @@ Quantcast.prototype.track = function(track) {
 
   var user = this.analytics.user();
   if (revenue != null) settings.revenue = String(revenue);
-  if (orderId) settings.orderid = orderId;
+  if (orderId) settings.orderid = String(orderId);
   if (user.id()) settings.uid = user.id();
   push(settings);
 };
@@ -161,7 +161,7 @@ Quantcast.prototype.completedOrder = function(track) {
     event: 'refresh',
     labels: labels,
     revenue: String(revenue),
-    orderid: track.orderId(),
+    orderid: String(track.orderId()),
     qacct: this.options.pCode
   };
   push(settings);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -238,6 +238,16 @@ describe('Quantcast', function() {
         });
       });
 
+      it('should convert orderId to string', function() {
+        analytics.track('event', { orderId: 123 });
+        analytics.called(window._qevents.push, {
+          event: 'click',
+          labels: 'event.event',
+          qacct: options.pCode,
+          orderid: '123'
+        });
+      });
+
       it('should handle completed order events', function() {
         analytics.track('completed order', {
           orderId: '780bc55',


### PR DESCRIPTION
Quantcast was dropping the `orderId` in its pixels if its value is not a string. We were already converting  `revenue` to a string so same applies for `orderId`. 

In reference to ticket: https://segment.zendesk.com/agent/tickets/28552

@ndhoule @sperand-io 
