### PR TITLE
Various Fixes and Updates

### DIFF
--- a/component.json
+++ b/component.json
@@ -8,8 +8,8 @@
   "dependencies": {
     "segmentio/analytics.js-integration": "^1.0.0",
     "segmentio/global-queue": "0.0.2",
-    "component/reduce": "1.0.1",
-    "segmentio/use-https": "0.1.0"
+    "segmentio/use-https": "0.1.0",
+    "ianstormtaylor/is": "0.1.1"
   },
   "development": {
     "segmentio/analytics.js-core": "^2.10.0",

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,10 +3,10 @@
  * Module dependencies.
  */
 
-var integration = require('analytics.js-integration');
 var push = require('global-queue')('_qevents', { wrap: false });
-var reduce = require('reduce');
+var integration = require('analytics.js-integration');
 var useHttps = require('use-https');
+var is = require('is');
 
 /**
  * Expose `Quantcast` integration.
@@ -40,7 +40,7 @@ Quantcast.prototype.initialize = function(page) {
   if (user.id()) settings.uid = user.id();
 
   if (page) {
-    settings.labels = this._labels('page', page.category(), page.name());
+    settings.labels = this._labels(page);
   }
 
   push(settings);
@@ -70,14 +70,9 @@ Quantcast.prototype.loaded = function() {
  */
 
 Quantcast.prototype.page = function(page) {
-  var category = page.category();
-  var name = page.name();
-  var customLabels = page.proxy('properties.label');
-  var labels = this._labels('page', category, name, customLabels);
-
   var settings = {
     event: 'refresh',
-    labels: labels,
+    labels: this._labels(page),
     qacct: this.options.pCode
   };
   var user = this.analytics.user();
@@ -114,22 +109,19 @@ Quantcast.prototype.identify = function(identify) {
  */
 
 Quantcast.prototype.track = function(track) {
-  var name = track.event();
-  var revenue = track.revenue();
-  var orderId = track.orderId();
-  var customLabels = track.proxy('properties.label');
-  var labels = this._labels('event', name, customLabels);
-
   var settings = {
     event: 'click',
-    labels: labels,
+    labels: this._labels(track),
     qacct: this.options.pCode
   };
 
+  var revenue = track.revenue();
+  var orderId = track.orderId();
   var user = this.analytics.user();
-  if (revenue != null) settings.revenue = String(revenue);
+  if (revenue) settings.revenue = String(revenue);
   if (orderId) settings.orderid = String(orderId);
   if (user.id()) settings.uid = user.id();
+
   push(settings);
 };
 
@@ -141,18 +133,15 @@ Quantcast.prototype.track = function(track) {
  */
 
 Quantcast.prototype.completedOrder = function(track) {
-  var name = track.event();
-  var revenue = track.total();
-  var customLabels = track.proxy('properties.label');
-  var labels = this._labels('event', name, customLabels);
-  var category = track.category();
-  var repeat = track.proxy('properties.repeat');
+  var labels = this._labels(track);
 
+  var category = safe(track.category());
   if (this.options.advertise && category) {
-    labels += ',' + this._labels('pcat', category);
+    labels += ',_fp.pcat.' + category;
   }
 
-  if (typeof repeat === 'boolean') {
+  var repeat = track.proxy('properties.repeat');
+  if (this.options.advertise && typeof repeat === 'boolean') {
     labels += ',_fp.customer.' + (repeat ? 'repeat' : 'new');
   }
 
@@ -160,46 +149,77 @@ Quantcast.prototype.completedOrder = function(track) {
     // the example Quantcast sent has completed order send refresh not click
     event: 'refresh',
     labels: labels,
-    revenue: String(revenue),
+    revenue: String(track.total()),
     orderid: String(track.orderId()),
     qacct: this.options.pCode
   };
+
   push(settings);
 };
 
 /**
  * Generate quantcast labels.
  *
- * Example:
+ * @api private
+ * @param {Object} facade
+ * @return {string}
+ *
+ * @example:
  *
  *    options.advertise = false;
- *    labels('event', 'my event');
+ *    labels(track);
  *    // => "event.my event"
+ *    labels(page);
+ *    // => "page.Category.Name"
  *
  *    options.advertise = true;
- *    labels('event', 'my event');
+ *    labels(track);
  *    // => "_fp.event.my event"
+ *    labels(page);
+ *    // => "_fp.event.Category.Name"
  *
- * @api private
- * @param {string} type
- * @param {...string} args
- * @return {string}
+ *  Return a string comprised of:
+ *
+ *  1) Prefix
+ *  2) Default Labels (dot delimited)
+ *     - page calls: (Category || 'All').(Name || 'Default)
+ *     - track calls: (Event Name)
+ *  3) Custom Labels (comma delimited)
+ *     - [properties.label, ...context.Quantcast.Labels]
  */
 
-Quantcast.prototype._labels = function(type) {
-  var args = Array.prototype.slice.call(arguments, 1);
-  var advertise = this.options.advertise;
+Quantcast.prototype._labels = function(facade) {
+  var prefix;
+  var action = facade.action();
+  if (action === 'page') prefix = 'page';
+  if (action === 'track') prefix = 'event';
+  if (this.options.advertise) prefix = '_fp.event';
 
-  if (advertise && type === 'page') type = 'event';
-  if (advertise) type = '_fp.' + type;
+  var autoLabels;
+  if (action === 'page') {
+    autoLabels = [
+      safe(facade.category()) || 'All',
+      safe(facade.name()) || 'Default'
+    ].join('.');
+  } else if (action === 'track') {
+    autoLabels = safe(facade.event());
+  }
 
-  var separator = advertise ? ' ' : '.';
-  var ret = reduce(args, function(ret, arg) {
-    if (arg != null) {
-      ret.push(String(arg).replace(/, /g, ','));
-    }
-    return ret;
-  }, []).join(separator);
+  var label = safe(facade.proxy('properties.label'));
+  var customLabels = facade.options('Quantcast').labels || [];
+  if (is.string(customLabels)) customLabels = [customLabels];
+  if (is.string(label)) customLabels.unshift(label);
+  customLabels = customLabels.join(',');
 
-  return [type, ret].join('.');
+  var ret = prefix + '.' + autoLabels;
+  if (customLabels) ret += ',' + customLabels;
+  return ret;
 };
+
+/**
+ * Remove Commas and Periods so that user can't accidentally mis-delimit labels
+ */
+
+function safe(str) {
+  if (str) return str.replace(/\.|\,/g, '');
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -76,6 +76,9 @@ Quantcast.prototype.page = function(page) {
     qacct: this.options.pCode
   };
   var user = this.analytics.user();
+
+  // For non-advertisers, blank labels are okay if no name/category is passed
+  if (!this.options.advertise && !page.name() && !page.category()) delete settings.labels;
   if (user.id()) settings.uid = user.id();
   push(settings);
 };
@@ -109,15 +112,15 @@ Quantcast.prototype.identify = function(identify) {
  */
 
 Quantcast.prototype.track = function(track) {
+  var revenue = track.revenue();
+  var orderId = track.orderId();
+  var user = this.analytics.user();
   var settings = {
     event: 'click',
     labels: this._labels(track),
     qacct: this.options.pCode
   };
 
-  var revenue = track.revenue();
-  var orderId = track.orderId();
-  var user = this.analytics.user();
   if (revenue) settings.revenue = String(revenue);
   if (orderId) settings.orderid = String(orderId);
   if (user.id()) settings.uid = user.id();
@@ -168,9 +171,9 @@ Quantcast.prototype.completedOrder = function(track) {
  *
  *    options.advertise = false;
  *    labels(track);
- *    // => "event.my event"
+ *    // => "my event"
  *    labels(page);
- *    // => "page.Category.Name"
+ *    // => "Category.Name"
  *
  *    options.advertise = true;
  *    labels(track);
@@ -182,43 +185,48 @@ Quantcast.prototype.completedOrder = function(track) {
  *
  *  1) Prefix
  *  2) Default Labels (dot delimited)
- *     - page calls: (Category || 'All').(Name || 'Default)
+ *     - page calls: (Category).(Name || 'Default')
  *     - track calls: (Event Name)
  *  3) Custom Labels (comma delimited)
  *     - [properties.label, ...context.Quantcast.Labels]
  */
 
 Quantcast.prototype._labels = function(facade) {
-  var prefix;
   var action = facade.action();
-  if (action === 'page') prefix = 'page';
-  if (action === 'track') prefix = 'event';
-  if (this.options.advertise) prefix = '_fp.event';
+  var autoLabels = [];
+  var ret;
 
-  var autoLabels;
   if (action === 'page') {
-    autoLabels = [
-      safe(facade.category()) || 'All',
-      safe(facade.name()) || 'Default'
-    ].join('.');
+    // There is no default for category
+    if (facade.category()) autoLabels.push(safe(facade.category()));
+    // Fallback on default label if no page name is given
+    autoLabels.push(safe(facade.name() || 'Default'));
+    autoLabels = autoLabels.join('.');
   } else if (action === 'track') {
     autoLabels = safe(facade.event());
   }
 
   var label = safe(facade.proxy('properties.label'));
-  var custom = facade.options('Quantcast').labels || [];
+  var customLabels = facade.options('Quantcast').labels || [];
 
   if (is.string(customLabels)) customLabels = [customLabels];
 
-  var customLabels = custom.map(function(label){
+  customLabels = customLabels.map(function(label){
     // strip special characters to prevent invalid labels
     return safe(label);
   });
 
   if (is.string(label)) customLabels.unshift(label);
+  // Multiple labels need to be delimited by commas
   customLabels = customLabels.join(',');
 
-  var ret = prefix + '.' + autoLabels;
+  // Non-advertisers require no prefix
+  if (this.options.advertise) {
+    ret = '_fp.event.' + autoLabels;
+  } else {
+    ret = autoLabels;
+  }
+
   if (customLabels) ret += ',' + customLabels;
   return ret;
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -206,8 +206,15 @@ Quantcast.prototype._labels = function(facade) {
   }
 
   var label = safe(facade.proxy('properties.label'));
-  var customLabels = facade.options('Quantcast').labels || [];
+  var custom = facade.options('Quantcast').labels || [];
+
   if (is.string(customLabels)) customLabels = [customLabels];
+
+  var customLabels = custom.map(function(label){
+    // strip special characters to prevent invalid labels
+    return safe(label);
+  });
+
   if (is.string(label)) customLabels.unshift(label);
   customLabels = customLabels.join(',');
 
@@ -217,9 +224,9 @@ Quantcast.prototype._labels = function(facade) {
 };
 
 /**
- * Remove Commas and Periods so that user can't accidentally mis-delimit labels
+ * Remove special characters so that user can't accidentally mis-delimit labels or create invalid labels
  */
 
 function safe(str) {
-  if (str) return str.replace(/\.|\,/g, '');
+  if (str) return str.replace(/[^\w\s]|_/gi, '');
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -235,6 +235,15 @@ describe('Quantcast', function() {
         });
       });
 
+      it('should strip special characters from labels', function() {
+        analytics.track('event', { label: 'new-Label?' }, { Quantcast: { labels: ['other!', 'labels_test()'] }});
+        analytics.called(window._qevents.push, {
+          event: 'click',
+          labels: 'event.event,newLabel,other,labelstest',
+          qacct: options.pCode
+        });
+      });
+
       it('should push custom labels from QC labels for the event', function() {
         analytics.track('event', { label: 'newLabel' }, { Quantcast: { labels: ['other', 'labels'] }});
         analytics.called(window._qevents.push, {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -67,7 +67,7 @@ describe('Quantcast', function() {
         var pushed = window._qevents[0];
         analytics.assert(options.pCode === pushed.qacct);
         analytics.assert(pushed.event == null);
-        analytics.assert(pushed.labels === 'page.category.name');
+        analytics.assert(pushed.labels === 'category.name');
       });
     });
   });
@@ -90,97 +90,116 @@ describe('Quantcast', function() {
         analytics.stub(window._qevents, 'push');
       });
 
-      it('should push a refresh event with pCode', function() {
-        analytics.page();
-        analytics.called(window._qevents.push, {
-          event: 'refresh',
-          labels: 'page.All.Default',
-          qacct: options.pCode
+      describe('when advertise is false', function() {
+        it('should push a refresh event with pCode', function() {
+          analytics.page();
+          analytics.called(window._qevents.push, {
+            event: 'refresh',
+            qacct: options.pCode
+          });
         });
-      });
 
-      it('should push the page name as a label', function() {
-        analytics.page('Page Name');
-        analytics.called(window._qevents.push, {
-          event: 'refresh',
-          labels: 'page.All.Page Name',
-          qacct: options.pCode
+        it('should push the page name as a label', function() {
+          analytics.page('Page Name');
+          analytics.called(window._qevents.push, {
+            event: 'refresh',
+            labels: 'Page Name',
+            qacct: options.pCode
+          });
         });
-      });
 
-      it('should push the page name as a label without commas', function() {
-        analytics.page('Page, Name');
-        analytics.called(window._qevents.push, {
-          event: 'refresh',
-          labels: 'page.All.Page Name',
-          qacct: options.pCode
+        it('should push the page name as a label without commas', function() {
+          analytics.page('Page, Name');
+          analytics.called(window._qevents.push, {
+            event: 'refresh',
+            labels: 'Page Name',
+            qacct: options.pCode
+          });
         });
-      });
 
-      it('should push the page category and name as labels', function() {
-        analytics.page('Category', 'Page');
-        analytics.called(window._qevents.push, {
-          event: 'refresh',
-          labels: 'page.Category.Page',
-          qacct: options.pCode
+        it('should push the page category and name as labels', function() {
+          analytics.page('Category', 'Page');
+          analytics.called(window._qevents.push, {
+            event: 'refresh',
+            labels: 'Category.Page',
+            qacct: options.pCode
+          });
         });
-      });
 
-      it('should add the properties labels to the custom label string', function() {
-        analytics.page('Category', 'Page', { label: 'TestLabel' });
-        analytics.called(window._qevents.push, {
-          event: 'refresh',
-          labels: 'page.Category.Page,TestLabel',
-          qacct: options.pCode
+        it('should add the properties labels to the custom label string', function() {
+          analytics.page('Category', 'Page', { label: 'TestLabel' });
+          analytics.called(window._qevents.push, {
+            event: 'refresh',
+            labels: 'Category.Page,TestLabel',
+            qacct: options.pCode
+          });
         });
-      });
 
-      it('should add the explicit QC labels to the custom label string', function() {
-        analytics.page('Category', 'Page', {}, { Quantcast: { labels: ['TestLabel', 'TestLabel2'] }});
-        analytics.called(window._qevents.push, {
-          event: 'refresh',
-          labels: 'page.Category.Page,TestLabel,TestLabel2',
-          qacct: options.pCode
+        it('should add the explicit QC labels to the custom label string', function() {
+          analytics.page('Category', 'Page', {}, { Quantcast: { labels: ['TestLabel', 'TestLabel2'] }});
+          analytics.called(window._qevents.push, {
+            event: 'refresh',
+            labels: 'Category.Page,TestLabel,TestLabel2',
+            qacct: options.pCode
+          });
         });
-      });
 
-      it('should add properties labels and the explicit QC labels to the custom label string', function() {
-        analytics.page('Category', 'Page', { label: 'TestLabel' }, { Quantcast: { labels: ['TestLabel1', 'TestLabel2'] }});
-        analytics.called(window._qevents.push, {
-          event: 'refresh',
-          labels: 'page.Category.Page,TestLabel,TestLabel1,TestLabel2',
-          qacct: options.pCode
+        it('should add properties labels and the explicit QC labels to the custom label string', function() {
+          analytics.page('Category', 'Page', { label: 'TestLabel' }, { Quantcast: { labels: ['TestLabel1', 'TestLabel2'] }});
+          analytics.called(window._qevents.push, {
+            event: 'refresh',
+            labels: 'Category.Page,TestLabel,TestLabel1,TestLabel2',
+            qacct: options.pCode
+          });
         });
-      });
 
-      it('should push the user id', function() {
-        analytics.user().identify('id');
-        analytics.page();
-        analytics.called(window._qevents.push, {
-          event: 'refresh',
-          labels: 'page.All.Default',
-          qacct: options.pCode,
-          uid: 'id'
+        it('should not send a label without name or category', function(){
+          analytics.page();
+          analytics.called(window._qevents.push, {
+            event: 'refresh',
+            qacct: options.pCode
+          });
+        });
+
+        it('should push the user id', function() {
+          analytics.user().identify('id');
+          analytics.page();
+          analytics.called(window._qevents.push, {
+            event: 'refresh',
+            qacct: options.pCode,
+            uid: 'id'
+          });
         });
       });
 
       describe('when advertise is true', function() {
-        it('should prefix with _fp.event', function() {
+        beforeEach(function() {
           quantcast.options.advertise = true;
+        });
+
+        it('should prefix with _fp.event', function() {
           analytics.page('Page Name');
           analytics.called(window._qevents.push, {
             event: 'refresh',
-            labels: '_fp.event.All.Page Name',
+            labels: '_fp.event.Page Name',
             qacct: options.pCode
           });
         });
 
         it('should send category and name', function() {
-          quantcast.options.advertise = true;
           analytics.page('Category Name', 'Page Name');
           analytics.called(window._qevents.push, {
             event: 'refresh',
             labels: '_fp.event.Category Name.Page Name',
+            qacct: options.pCode
+          });
+        });
+
+        it('should fallback on default when no name is passed', function() {
+          analytics.page();
+          analytics.called(window._qevents.push, {
+            event: 'refresh',
+            labels: '_fp.event.Default',
             qacct: options.pCode
           });
         });
@@ -207,194 +226,196 @@ describe('Quantcast', function() {
         analytics.stub(window._qevents, 'push');
       });
 
-      it('should push a click event', function() {
-        analytics.track('event');
-        analytics.called(window._qevents.push, {
-          event: 'click',
-          labels: 'event.event',
-          qacct: options.pCode
+      describe('when advertiser is false', function() {
+        it('should push a click event', function() {
+          analytics.track('event');
+          analytics.called(window._qevents.push, {
+            event: 'click',
+            labels: 'event',
+            qacct: options.pCode
+          });
         });
-      });
 
-      it('should push revenue for the event', function() {
-        analytics.track('event', { revenue: 10.45 });
-        analytics.called(window._qevents.push, {
-          event: 'click',
-          labels: 'event.event',
-          qacct: options.pCode,
-          revenue: '10.45'
+        it('should push revenue for the event', function() {
+          analytics.track('event', { revenue: 10.45 });
+          analytics.called(window._qevents.push, {
+            event: 'click',
+            labels: 'event',
+            qacct: options.pCode,
+            revenue: '10.45'
+          });
         });
-      });
 
-      it('should push custom label from properties for the event', function() {
-        analytics.track('event', { label: 'newLabel' });
-        analytics.called(window._qevents.push, {
-          event: 'click',
-          labels: 'event.event,newLabel',
-          qacct: options.pCode
+        it('should push custom label from properties for the event', function() {
+          analytics.track('event', { label: 'newLabel' });
+          analytics.called(window._qevents.push, {
+            event: 'click',
+            labels: 'event,newLabel',
+            qacct: options.pCode
+          });
         });
-      });
 
-      it('should strip special characters from labels', function() {
-        analytics.track('event', { label: 'new-Label?' }, { Quantcast: { labels: ['other!', 'labels_test()'] }});
-        analytics.called(window._qevents.push, {
-          event: 'click',
-          labels: 'event.event,newLabel,other,labelstest',
-          qacct: options.pCode
+        it('should strip special characters from labels', function() {
+          analytics.track('event', { label: 'new-Label?' }, { Quantcast: { labels: ['other!', 'labels_test()'] }});
+          analytics.called(window._qevents.push, {
+            event: 'click',
+            labels: 'event,newLabel,other,labelstest',
+            qacct: options.pCode
+          });
         });
-      });
 
-      it('should push custom labels from QC labels for the event', function() {
-        analytics.track('event', { label: 'newLabel' }, { Quantcast: { labels: ['other', 'labels'] }});
-        analytics.called(window._qevents.push, {
-          event: 'click',
-          labels: 'event.event,newLabel,other,labels',
-          qacct: options.pCode
+        it('should push custom labels from QC labels for the event', function() {
+          analytics.track('event', { label: 'newLabel' }, { Quantcast: { labels: ['other', 'labels'] }});
+          analytics.called(window._qevents.push, {
+            event: 'click',
+            labels: 'event,newLabel,other,labels',
+            qacct: options.pCode
+          });
         });
-      });
 
-      it('should push the user id', function() {
-        analytics.user().identify('id');
-        analytics.track('event');
-        analytics.called(window._qevents.push, {
-          event: 'click',
-          labels: 'event.event',
-          qacct: options.pCode,
-          uid: 'id'
+        it('should push the user id', function() {
+          analytics.user().identify('id');
+          analytics.track('event');
+          analytics.called(window._qevents.push, {
+            event: 'click',
+            labels: 'event',
+            qacct: options.pCode,
+            uid: 'id'
+          });
         });
-      });
 
-      it('should push the orderid', function() {
-        analytics.track('event', { orderId: '123' });
-        analytics.called(window._qevents.push, {
-          event: 'click',
-          labels: 'event.event',
-          qacct: options.pCode,
-          orderid: '123'
+        it('should push the orderid', function() {
+          analytics.track('event', { orderId: '123' });
+          analytics.called(window._qevents.push, {
+            event: 'click',
+            labels: 'event',
+            qacct: options.pCode,
+            orderid: '123'
+          });
         });
-      });
 
-      it('should convert orderId to string', function() {
-        analytics.track('event', { orderId: 123 });
-        analytics.called(window._qevents.push, {
-          event: 'click',
-          labels: 'event.event',
-          qacct: options.pCode,
-          orderid: '123'
+        it('should convert orderId to string', function() {
+          analytics.track('event', { orderId: 123 });
+          analytics.called(window._qevents.push, {
+            event: 'click',
+            labels: 'event',
+            qacct: options.pCode,
+            orderid: '123'
+          });
         });
-      });
 
-      it('should handle completed order events', function() {
-        analytics.track('completed order', {
-          orderId: '780bc55',
-          category: 'tech',
-          total: 99.99,
-          shipping: 13.99,
-          tax: 20.99,
-          products: [{
-            quantity: 1,
-            price: 24.75,
-            name: 'my product',
-            sku: 'p-298'
-          }, {
-            quantity: 3,
-            price: 24.75,
-            name: 'other product',
-            sku: 'p-299'
-          }]
+        it('should handle completed order events', function() {
+          analytics.track('completed order', {
+            orderId: '780bc55',
+            category: 'tech',
+            total: 99.99,
+            shipping: 13.99,
+            tax: 20.99,
+            products: [{
+              quantity: 1,
+              price: 24.75,
+              name: 'my product',
+              sku: 'p-298'
+            }, {
+              quantity: 3,
+              price: 24.75,
+              name: 'other product',
+              sku: 'p-299'
+            }]
+          });
+          analytics.called(window._qevents.push, {
+            event: 'refresh',
+            labels: 'completed order',
+            orderid: '780bc55',
+            qacct: options.pCode,
+            revenue: '99.99'
+          });
         });
-        analytics.called(window._qevents.push, {
-          event: 'refresh',
-          labels: 'event.completed order',
-          orderid: '780bc55',
-          qacct: options.pCode,
-          revenue: '99.99'
-        });
-      });
 
-      it('should set repeat property if present', function() {
-        analytics.track('completed order', {
-          orderId: '780bc55',
-          category: 'tech',
-          total: 99.99,
-          shipping: 13.99,
-          tax: 20.99,
-          repeat: false,
-          products: [{
-            quantity: 1,
-            price: 24.75,
-            name: 'my product',
-            sku: 'p-298'
-          }, {
-            quantity: 3,
-            price: 24.75,
-            name: 'other product',
-            sku: 'p-299'
-          }]
+        it('should set repeat property if present', function() {
+          analytics.track('completed order', {
+            orderId: '780bc55',
+            category: 'tech',
+            total: 99.99,
+            shipping: 13.99,
+            tax: 20.99,
+            repeat: false,
+            products: [{
+              quantity: 1,
+              price: 24.75,
+              name: 'my product',
+              sku: 'p-298'
+            }, {
+              quantity: 3,
+              price: 24.75,
+              name: 'other product',
+              sku: 'p-299'
+            }]
+          });
+          analytics.called(window._qevents.push, {
+            event: 'refresh',
+            labels: 'completed order',
+            orderid: '780bc55',
+            qacct: options.pCode,
+            revenue: '99.99'
+          });
         });
-        analytics.called(window._qevents.push, {
-          event: 'refresh',
-          labels: 'event.completed order',
-          orderid: '780bc55',
-          qacct: options.pCode,
-          revenue: '99.99'
-        });
-      });
 
-      it('should not set repeat label if repeat property not present', function() {
-        analytics.track('completed order', {
-          orderId: '780bc55',
-          category: 'tech',
-          total: 99.99,
-          shipping: 13.99,
-          tax: 20.99,
-          products: [{
-            quantity: 1,
-            price: 24.75,
-            name: 'my product',
-            sku: 'p-298'
-          }, {
-            quantity: 3,
-            price: 24.75,
-            name: 'other product',
-            sku: 'p-299'
-          }]
+        it('should not set repeat label if repeat property not present', function() {
+          analytics.track('completed order', {
+            orderId: '780bc55',
+            category: 'tech',
+            total: 99.99,
+            shipping: 13.99,
+            tax: 20.99,
+            products: [{
+              quantity: 1,
+              price: 24.75,
+              name: 'my product',
+              sku: 'p-298'
+            }, {
+              quantity: 3,
+              price: 24.75,
+              name: 'other product',
+              sku: 'p-299'
+            }]
+          });
+          analytics.called(window._qevents.push, {
+            event: 'refresh',
+            labels: 'completed order',
+            orderid: '780bc55',
+            qacct: options.pCode,
+            revenue: '99.99'
+          });
         });
-        analytics.called(window._qevents.push, {
-          event: 'refresh',
-          labels: 'event.completed order',
-          orderid: '780bc55',
-          qacct: options.pCode,
-          revenue: '99.99'
-        });
-      });
 
-      it('should set repeat label to "repeat" if true', function() {
-        analytics.track('completed order', {
-          orderId: '780bc55',
-          category: 'tech',
-          total: 99.99,
-          shipping: 13.99,
-          tax: 20.99,
-          repeat: true,
-          products: [{
-            quantity: 1,
-            price: 24.75,
-            name: 'my product',
-            sku: 'p-298'
-          }, {
-            quantity: 3,
-            price: 24.75,
-            name: 'other product',
-            sku: 'p-299'
-          }]
-        });
-        analytics.called(window._qevents.push, {
-          event: 'refresh',
-          labels: 'event.completed order',
-          orderid: '780bc55',
-          qacct: options.pCode,
-          revenue: '99.99'
+        it('should set repeat label to "repeat" if true', function() {
+          analytics.track('completed order', {
+            orderId: '780bc55',
+            category: 'tech',
+            total: 99.99,
+            shipping: 13.99,
+            tax: 20.99,
+            repeat: true,
+            products: [{
+              quantity: 1,
+              price: 24.75,
+              name: 'my product',
+              sku: 'p-298'
+            }, {
+              quantity: 3,
+              price: 24.75,
+              name: 'other product',
+              sku: 'p-299'
+            }]
+          });
+          analytics.called(window._qevents.push, {
+            event: 'refresh',
+            labels: 'completed order',
+            orderid: '780bc55',
+            qacct: options.pCode,
+            revenue: '99.99'
+          });
         });
       });
 


### PR DESCRIPTION
Started by adding fallbacks for name and category per QC's request, but [this old issue](https://github.com/segmentio/analytics.js-integrations/pull/515) caught my eye and I wanted to make sure we got in those fixes as well.

Fixes:

- Add defaults for page labels — `page.name() || 'Default'` and `page.category() || 'All'`
- Previously, we weren't stripping periods and commas from labels, which meant users could mess up delimiting by passing a string that included a comma
- Delimit "Custom Labels" with a Comma

@hankim813 can you handle confirming with QC that these are in line with expectations and look good to them (and update docs :sheep: :grimacing: )?