### PR TITLE
update ecommerce syntax from v1 to v2

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -127,13 +127,13 @@ Quantcast.prototype.track = function(track) {
 };
 
 /**
- * Completed Order.
+ * Order Completed
  *
  * @api private
  * @param {Track} track
  */
 
-Quantcast.prototype.completedOrder = function(track) {
+Quantcast.prototype.orderCompleted = function(track) {
   var labels = this._labels(track);
 
   var category = safe(track.category());

--- a/package.json
+++ b/package.json
@@ -23,14 +23,14 @@
   },
   "homepage": "https://github.com/segment-integrations/analytics.js-integration-quantcast#readme",
   "dependencies": {
-    "@segment/analytics.js-integration": "^2.1.0",
+    "@segment/analytics.js-integration": "^3.1.0",
     "global-queue": "^1.0.1",
     "is": "^3.1.0",
     "use-https": "^0.1.1"
   },
   "devDependencies": {
     "@segment/analytics.js-core": "^3.0.0",
-    "@segment/analytics.js-integration-tester": "^2.0.0",
+    "@segment/analytics.js-integration-tester": "^3.0.0",
     "@segment/clear-env": "^2.0.0",
     "@segment/eslint-config": "^3.1.1",
     "browserify": "^13.0.0",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -338,8 +338,8 @@ describe('Quantcast', function() {
           });
         });
 
-        it('should handle completed order events', function() {
-          analytics.track('completed order', {
+        it('should handle order completed events', function() {
+          analytics.track('order completed', {
             orderId: '780bc55',
             category: 'tech',
             total: 99.99,
@@ -359,7 +359,7 @@ describe('Quantcast', function() {
           });
           analytics.called(window._qevents.push, {
             event: 'refresh',
-            labels: 'completed order',
+            labels: 'order completed',
             orderid: '780bc55',
             qacct: options.pCode,
             revenue: '99.99'
@@ -367,7 +367,7 @@ describe('Quantcast', function() {
         });
 
         it('should set repeat property if present', function() {
-          analytics.track('completed order', {
+          analytics.track('order completed', {
             orderId: '780bc55',
             category: 'tech',
             total: 99.99,
@@ -388,7 +388,7 @@ describe('Quantcast', function() {
           });
           analytics.called(window._qevents.push, {
             event: 'refresh',
-            labels: 'completed order',
+            labels: 'order completed',
             orderid: '780bc55',
             qacct: options.pCode,
             revenue: '99.99'
@@ -396,7 +396,7 @@ describe('Quantcast', function() {
         });
 
         it('should not set repeat label if repeat property not present', function() {
-          analytics.track('completed order', {
+          analytics.track('order completed', {
             orderId: '780bc55',
             category: 'tech',
             total: 99.99,
@@ -416,7 +416,7 @@ describe('Quantcast', function() {
           });
           analytics.called(window._qevents.push, {
             event: 'refresh',
-            labels: 'completed order',
+            labels: 'order completed',
             orderid: '780bc55',
             qacct: options.pCode,
             revenue: '99.99'
@@ -424,7 +424,7 @@ describe('Quantcast', function() {
         });
 
         it('should set repeat label to "repeat" if true', function() {
-          analytics.track('completed order', {
+          analytics.track('order completed', {
             orderId: '780bc55',
             category: 'tech',
             total: 99.99,
@@ -445,7 +445,7 @@ describe('Quantcast', function() {
           });
           analytics.called(window._qevents.push, {
             event: 'refresh',
-            labels: 'completed order',
+            labels: 'order completed',
             orderid: '780bc55',
             qacct: options.pCode,
             revenue: '99.99'
@@ -464,9 +464,9 @@ describe('Quantcast', function() {
           });
         });
 
-        it('should handle completed order events', function() {
+        it('should handle order completed events', function() {
           quantcast.options.advertise = true;
-          analytics.track('completed order', {
+          analytics.track('order completed', {
             orderId: '780bc55',
             category: 'tech',
             repeat: true,
@@ -487,7 +487,7 @@ describe('Quantcast', function() {
           });
           analytics.called(window._qevents.push, {
             event: 'refresh',
-            labels: '_fp.event.completed order,_fp.pcat.tech,_fp.customer.repeat',
+            labels: '_fp.event.order completed,_fp.pcat.tech,_fp.customer.repeat',
             orderid: '780bc55',
             qacct: options.pCode,
             revenue: '99.99'
@@ -496,7 +496,7 @@ describe('Quantcast', function() {
 
         it('should respect repeat:false as new customer', function() {
           quantcast.options.advertise = true;
-          analytics.track('completed order', {
+          analytics.track('order completed', {
             orderId: '780bc55',
             category: 'tech',
             repeat: false,
@@ -517,7 +517,7 @@ describe('Quantcast', function() {
           });
           analytics.called(window._qevents.push, {
             event: 'refresh',
-            labels: '_fp.event.completed order,_fp.pcat.tech,_fp.customer.new',
+            labels: '_fp.event.order completed,_fp.pcat.tech,_fp.customer.new',
             orderid: '780bc55',
             qacct: options.pCode,
             revenue: '99.99'


### PR DESCRIPTION
This PR changes the ecommerce V1 syntax Action + Object to the new V2 syntax, Object + Action.

This PR will be waiting on a few blockers, a refactor of the Analytics-Events repo to be more concise and readable as we add more events to our spec and for similar changes to be made to all other integrations currently using V1 syntax.

Tests are failing because it isn't properly aliasing against the new spec'd events. These tests will need to pass, dependent on a new version of Analytics Events and Analytics.js-Private before being merged.