### PR TITLE
Total overrides revenue if both are passed

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,9 @@
 
+2.1.2 / 2017-05-17
+==================
+
+* Pass total || revenue for completed order events
+
 2.1.1 / 2016-08-16
 ==================
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -110,7 +110,7 @@ Quantcast.prototype.identify = function(identify) {
  */
 
 Quantcast.prototype.track = function(track) {
-  var revenue = track.revenue();
+  var revenue = track.total() || track.revenue();
   var orderId = track.orderId();
   var user = this.analytics.user();
   var settings = {
@@ -150,7 +150,7 @@ Quantcast.prototype.orderCompleted = function(track) {
     // the example Quantcast sent has completed order send refresh not click
     event: 'refresh',
     labels: labels,
-    revenue: String(track.total()),
+    revenue: String(track.total() || track.revenue()),
     orderid: String(track.orderId()),
     qacct: this.options.pCode
   };

--- a/lib/index.js
+++ b/lib/index.js
@@ -110,7 +110,7 @@ Quantcast.prototype.identify = function(identify) {
  */
 
 Quantcast.prototype.track = function(track) {
-  var revenue = track.total() || track.revenue();
+  var revenue = track.revenue();
   var orderId = track.orderId();
   var user = this.analytics.user();
   var settings = {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-quantcast",
   "description": "The Quantcast analytics.js integration.",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -256,6 +256,16 @@ describe('Quantcast', function() {
           });
         });
 
+        it('should push total in place of revenue if both are passed for the event', function() {
+          analytics.track('event', { total: 12.45 });
+          analytics.called(window._qevents.push, {
+            event: 'click',
+            labels: 'event',
+            qacct: options.pCode,
+            revenue: '12.45'
+          });
+        });
+
         it('should push custom label from properties for the event', function() {
           analytics.track('event', { label: 'newLabel' });
           analytics.called(window._qevents.push, {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -256,16 +256,6 @@ describe('Quantcast', function() {
           });
         });
 
-        it('should push total in place of revenue if both are passed for the event', function() {
-          analytics.track('event', { total: 12.45 });
-          analytics.called(window._qevents.push, {
-            event: 'click',
-            labels: 'event',
-            qacct: options.pCode,
-            revenue: '12.45'
-          });
-        });
-
         it('should push custom label from properties for the event', function() {
           analytics.track('event', { label: 'newLabel' });
           analytics.called(window._qevents.push, {


### PR DESCRIPTION
Ensures that customers can pass *either* "total" or "revenue" for "Order Completed" events, preserving backwards compatibility. @hankim813 