### PR TITLE
feat(track): add products for order completed event

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,7 @@ var push = require('global-queue')('_qevents', { wrap: false });
 var integration = require('@segment/analytics.js-integration');
 var useHttps = require('use-https');
 var is = require('is');
+var reject = require('reject');
 
 /**
  * Expose `Quantcast` integration.
@@ -144,6 +145,25 @@ Quantcast.prototype.orderCompleted = function(track) {
   var repeat = track.proxy('properties.repeat');
   if (this.options.advertise && typeof repeat === 'boolean') {
     labels += ',_fp.customer.' + (repeat ? 'repeat' : 'new');
+  }
+
+  var products = track.products();
+  if (products.length) {
+    products.reduce(function(product) {
+      var params = reject({
+        ProductId: product.productId,
+        Name: product.name,
+        SKU: product.sku
+      });
+
+      for (var param in params) {
+        if (params.hasOwnPropery(param)) {
+          labels += '_fp.pcat.' + param + '=' + params[param];
+        }
+      }
+
+      return labels;
+    }, labels);
   }
 
   var settings = {

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,7 @@ var push = require('global-queue')('_qevents', { wrap: false });
 var integration = require('@segment/analytics.js-integration');
 var useHttps = require('use-https');
 var is = require('is');
+var objCase = require('obj-case');
 
 /**
  * Expose `Quantcast` integration.
@@ -169,10 +170,10 @@ Quantcast.prototype.orderCompleted = function(track) {
 
   track.products().forEach(function(product) {
     // only include products with an ID (as required by the spec)
-    if (!product.product_id) return;
+    if (!objCase.find(product, 'product_id')) return;
 
     Object.keys(productLabelMap).forEach(function(key) {
-      var value = product[key];
+      var value = objCase.find(product, key);
       var label = productLabelMap[key];
       if (value) labels += ',_fp.pcat.' + label + '=' + value;
     });

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,7 +8,6 @@ var push = require('global-queue')('_qevents', { wrap: false });
 var integration = require('@segment/analytics.js-integration');
 var useHttps = require('use-https');
 var is = require('is');
-var reject = require('reject');
 
 /**
  * Expose `Quantcast` integration.
@@ -128,6 +127,27 @@ Quantcast.prototype.track = function(track) {
 };
 
 /**
+ * A map of product attributes to quantcast labels.
+ *
+ * @type {Object}
+ */
+
+var productLabelMap = {
+  product_id: 'ProductID',
+  sku: 'SKU',
+  category: 'Category',
+  name: 'Name',
+  brand: 'Brand',
+  variant: 'Variant',
+  price: 'Price',
+  quantity: 'Quantity',
+  coupon: 'Coupon',
+  position: 'Position',
+  url: 'URL',
+  image_url: 'ImageURL'
+};
+
+/**
  * Order Completed
  *
  * @api private
@@ -147,24 +167,16 @@ Quantcast.prototype.orderCompleted = function(track) {
     labels += ',_fp.customer.' + (repeat ? 'repeat' : 'new');
   }
 
-  var products = track.products();
-  if (products.length) {
-    products.reduce(function(product) {
-      var params = reject({
-        ProductId: product.productId,
-        Name: product.name,
-        SKU: product.sku
-      });
+  track.products().forEach(function(product) {
+    // only include products with an ID (as required by the spec)
+    if (!product.product_id) return;
 
-      for (var param in params) {
-        if (params.hasOwnPropery(param)) {
-          labels += '_fp.pcat.' + param + '=' + params[param];
-        }
-      }
-
-      return labels;
-    }, labels);
-  }
+    Object.keys(productLabelMap).forEach(function(key) {
+      var value = product[key];
+      var label = productLabelMap[key];
+      if (value) labels += ',_fp.pcat.' + label + '=' + value;
+    });
+  });
 
   var settings = {
     // the example Quantcast sent has completed order send refresh not click

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@segment/analytics.js-integration": "^3.1.0",
     "global-queue": "^1.0.1",
     "is": "^3.1.0",
+    "obj-case": "0.x",
     "use-https": "^0.1.1"
   },
   "devDependencies": {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -331,22 +331,44 @@ describe('Quantcast', function() {
             category: 'tech',
             total: 99.99,
             shipping: 13.99,
-            tax: 20.99,
-            products: [{
-              quantity: 1,
-              price: 24.75,
-              name: 'my product',
-              sku: 'p-298'
-            }, {
-              quantity: 3,
-              price: 24.75,
-              name: 'other product',
-              sku: 'p-299'
-            }]
+            tax: 20.99
           });
           analytics.called(window._qevents.push, {
             event: 'refresh',
             labels: 'order completed',
+            orderid: '780bc55',
+            qacct: options.pCode,
+            revenue: '99.99'
+          });
+        });
+
+        it('should handle include products for order completed events', function() {
+          analytics.track('order completed', {
+            orderId: '780bc55',
+            category: 'tech',
+            total: 99.99,
+            shipping: 13.99,
+            tax: 20.99,
+            products: [
+              {
+                product_id: 'product_1',
+                quantity: 1,
+                price: 24.75,
+                name: 'my product',
+                sku: 'p-298'
+              },
+              {
+                product_id: 'product_2',
+                quantity: 3,
+                price: 24.75,
+                name: 'other product',
+                sku: 'p-299'
+              }
+            ]
+          });
+          analytics.called(window._qevents.push, {
+            event: 'refresh',
+            labels: 'order completed,_fp.pcat.ProductID=product_1,_fp.pcat.SKU=p-298,_fp.pcat.Name=my product,_fp.pcat.Price=24.75,_fp.pcat.Quantity=1,_fp.pcat.ProductID=product_2,_fp.pcat.SKU=p-299,_fp.pcat.Name=other product,_fp.pcat.Price=24.75,_fp.pcat.Quantity=3',
             orderid: '780bc55',
             qacct: options.pCode,
             revenue: '99.99'
@@ -360,18 +382,7 @@ describe('Quantcast', function() {
             total: 99.99,
             shipping: 13.99,
             tax: 20.99,
-            repeat: false,
-            products: [{
-              quantity: 1,
-              price: 24.75,
-              name: 'my product',
-              sku: 'p-298'
-            }, {
-              quantity: 3,
-              price: 24.75,
-              name: 'other product',
-              sku: 'p-299'
-            }]
+            repeat: false
           });
           analytics.called(window._qevents.push, {
             event: 'refresh',
@@ -388,18 +399,7 @@ describe('Quantcast', function() {
             category: 'tech',
             total: 99.99,
             shipping: 13.99,
-            tax: 20.99,
-            products: [{
-              quantity: 1,
-              price: 24.75,
-              name: 'my product',
-              sku: 'p-298'
-            }, {
-              quantity: 3,
-              price: 24.75,
-              name: 'other product',
-              sku: 'p-299'
-            }]
+            tax: 20.99
           });
           analytics.called(window._qevents.push, {
             event: 'refresh',
@@ -417,18 +417,7 @@ describe('Quantcast', function() {
             total: 99.99,
             shipping: 13.99,
             tax: 20.99,
-            repeat: true,
-            products: [{
-              quantity: 1,
-              price: 24.75,
-              name: 'my product',
-              sku: 'p-298'
-            }, {
-              quantity: 3,
-              price: 24.75,
-              name: 'other product',
-              sku: 'p-299'
-            }]
+            repeat: true
           });
           analytics.called(window._qevents.push, {
             event: 'refresh',
@@ -459,22 +448,45 @@ describe('Quantcast', function() {
             repeat: true,
             total: 99.99,
             shipping: 13.99,
-            tax: 20.99,
-            products: [{
-              quantity: 1,
-              price: 24.75,
-              name: 'my product',
-              sku: 'p-298'
-            }, {
-              quantity: 3,
-              price: 24.75,
-              name: 'other product',
-              sku: 'p-299'
-            }]
+            tax: 20.99
           });
           analytics.called(window._qevents.push, {
             event: 'refresh',
             labels: '_fp.event.order completed,_fp.pcat.tech,_fp.customer.repeat',
+            orderid: '780bc55',
+            qacct: options.pCode,
+            revenue: '99.99'
+          });
+        });
+
+        it('should handle include products for order completed events', function() {
+          quantcast.options.advertise = true;
+          analytics.track('order completed', {
+            orderId: '780bc55',
+            category: 'tech',
+            total: 99.99,
+            shipping: 13.99,
+            tax: 20.99,
+            products: [
+              {
+                product_id: 'product_1',
+                quantity: 1,
+                price: 24.75,
+                name: 'my product',
+                sku: 'p-298'
+              },
+              {
+                product_id: 'product_2',
+                quantity: 3,
+                price: 24.75,
+                name: 'other product',
+                sku: 'p-299'
+              }
+            ]
+          });
+          analytics.called(window._qevents.push, {
+            event: 'refresh',
+            labels: '_fp.event.order completed,_fp.pcat.tech,_fp.pcat.ProductID=product_1,_fp.pcat.SKU=p-298,_fp.pcat.Name=my product,_fp.pcat.Price=24.75,_fp.pcat.Quantity=1,_fp.pcat.ProductID=product_2,_fp.pcat.SKU=p-299,_fp.pcat.Name=other product,_fp.pcat.Price=24.75,_fp.pcat.Quantity=3',
             orderid: '780bc55',
             qacct: options.pCode,
             revenue: '99.99'
@@ -489,18 +501,7 @@ describe('Quantcast', function() {
             repeat: false,
             total: 99.99,
             shipping: 13.99,
-            tax: 20.99,
-            products: [{
-              quantity: 1,
-              price: 24.75,
-              name: 'my product',
-              sku: 'p-298'
-            }, {
-              quantity: 3,
-              price: 24.75,
-              name: 'other product',
-              sku: 'p-299'
-            }]
+            tax: 20.99
           });
           analytics.called(window._qevents.push, {
             event: 'refresh',

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -351,14 +351,14 @@ describe('Quantcast', function() {
             tax: 20.99,
             products: [
               {
-                product_id: 'product_1',
+                productId: 'product_1',
                 quantity: 1,
                 price: 24.75,
                 name: 'my product',
                 sku: 'p-298'
               },
               {
-                product_id: 'product_2',
+                productId: 'product_2',
                 quantity: 3,
                 price: 24.75,
                 name: 'other product',
@@ -469,14 +469,14 @@ describe('Quantcast', function() {
             tax: 20.99,
             products: [
               {
-                product_id: 'product_1',
+                productId: 'product_1',
                 quantity: 1,
                 price: 24.75,
                 name: 'my product',
                 sku: 'p-298'
               },
               {
-                product_id: 'product_2',
+                productId: 'product_2',
                 quantity: 3,
                 price: 24.75,
                 name: 'other product',


### PR DESCRIPTION
**JIRA: [PLATFORM-1462](https://segment.atlassian.net/browse/PLATFORM-1462)**

This adds support for including `products` during "Order Completed" events. For each product, it will add labels that correspond to the products being tracked, using our ecommerce spec to determine what to send.

We're relying on Quantcast telling us what to do here, so we're assuming it will work as designed. (see ticket comment thread for more context)