### PR TITLE
PLATFORM-1462: follow up with changes from quantcast team

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -134,18 +134,21 @@ Quantcast.prototype.track = function(track) {
  */
 
 var productLabelMap = {
+  brand: 'Brand',
+  category: 'Category',
+  coupon: 'Coupon',
+  image_url: 'ImageURL',
+  name: 'Name',
+  position: 'Position',
   product_id: 'ProductID',
   sku: 'SKU',
-  category: 'Category',
-  name: 'Name',
-  brand: 'Brand',
-  variant: 'Variant',
-  price: 'Price',
-  quantity: 'Quantity',
-  coupon: 'Coupon',
-  position: 'Position',
   url: 'URL',
-  image_url: 'ImageURL'
+  variant: 'Variant'
+
+  // the following spec-ed properties are not being included as labels at the
+  // request of the Quantcast team:
+  //  - price
+  //  - quantity
 };
 
 /**
@@ -178,6 +181,17 @@ Quantcast.prototype.orderCompleted = function(track) {
       if (value) labels += ',_fp.pcat.' + label + '.' + value;
     });
   });
+
+  // Here, we are extracting a single quantity for all products in the event.
+  // This doesn't make a whole lot of sense to me, but the Quantcast team
+  // requested this change.
+  var quantity = track.products().reduce(function(acc, product) {
+    var quantity = objCase.find(product, 'quantity');
+    if (typeof quantity === 'number') return acc + quantity;
+    if (typeof quantity === 'string') return acc + parseInt(quantity, 10);
+    return acc;
+  }, 0);
+  if (quantity > 0) labels += ',_fp.pcat.Quantity.' + quantity;
 
   var settings = {
     // the example Quantcast sent has completed order send refresh not click

--- a/lib/index.js
+++ b/lib/index.js
@@ -161,37 +161,39 @@ var productLabelMap = {
 Quantcast.prototype.orderCompleted = function(track) {
   var labels = this._labels(track);
 
-  var category = safe(track.category());
-  if (this.options.advertise && category) {
-    labels += ',_fp.pcat.' + category;
+  if (this.options.advertise) {
+    var category = safe(track.category());
+    if (category) labels += ',_fp.pcat.' + category;
+
+    var repeat = track.proxy('properties.repeat');
+    if (typeof repeat === 'boolean') labels += ',_fp.customer.' + (repeat ? 'repeat' : 'new');
+
+    if (this.options.advertiseProducts) {
+      var products = track.products();
+
+      products.forEach(function(product) {
+        // only include products with an ID (as required by the spec)
+        if (!objCase.find(product, 'product_id')) return;
+
+        Object.keys(productLabelMap).forEach(function(key) {
+          var value = objCase.find(product, key);
+          var label = productLabelMap[key];
+          if (value) labels += ',_fp.pcat.' + label + '.' + value;
+        });
+      });
+
+      // Here, we are extracting a single quantity for all products in the event.
+      // This doesn't make a whole lot of sense to me, but the Quantcast team
+      // requested this change.
+      var quantity = products.reduce(function(acc, product) {
+        var quantity = objCase.find(product, 'quantity');
+        if (typeof quantity === 'number') return acc + quantity;
+        if (typeof quantity === 'string') return acc + parseInt(quantity, 10);
+        return acc;
+      }, 0);
+      if (quantity > 0) labels += ',_fp.pcat.Quantity.' + quantity;
+    }
   }
-
-  var repeat = track.proxy('properties.repeat');
-  if (this.options.advertise && typeof repeat === 'boolean') {
-    labels += ',_fp.customer.' + (repeat ? 'repeat' : 'new');
-  }
-
-  track.products().forEach(function(product) {
-    // only include products with an ID (as required by the spec)
-    if (!objCase.find(product, 'product_id')) return;
-
-    Object.keys(productLabelMap).forEach(function(key) {
-      var value = objCase.find(product, key);
-      var label = productLabelMap[key];
-      if (value) labels += ',_fp.pcat.' + label + '.' + value;
-    });
-  });
-
-  // Here, we are extracting a single quantity for all products in the event.
-  // This doesn't make a whole lot of sense to me, but the Quantcast team
-  // requested this change.
-  var quantity = track.products().reduce(function(acc, product) {
-    var quantity = objCase.find(product, 'quantity');
-    if (typeof quantity === 'number') return acc + quantity;
-    if (typeof quantity === 'string') return acc + parseInt(quantity, 10);
-    return acc;
-  }, 0);
-  if (quantity > 0) labels += ',_fp.pcat.Quantity.' + quantity;
 
   var settings = {
     // the example Quantcast sent has completed order send refresh not click

--- a/lib/index.js
+++ b/lib/index.js
@@ -175,7 +175,7 @@ Quantcast.prototype.orderCompleted = function(track) {
     Object.keys(productLabelMap).forEach(function(key) {
       var value = objCase.find(product, key);
       var label = productLabelMap[key];
-      if (value) labels += ',_fp.pcat.' + label + '=' + value;
+      if (value) labels += ',_fp.pcat.' + label + '.' + value;
     });
   });
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -342,39 +342,6 @@ describe('Quantcast', function() {
           });
         });
 
-        it('should handle include products for order completed events', function() {
-          analytics.track('order completed', {
-            orderId: '780bc55',
-            category: 'tech',
-            total: 99.99,
-            shipping: 13.99,
-            tax: 20.99,
-            products: [
-              {
-                productId: 'product_1',
-                quantity: 1,
-                price: 24.75,
-                name: 'my product',
-                sku: 'p-298'
-              },
-              {
-                productId: 'product_2',
-                quantity: 3,
-                price: 24.75,
-                name: 'other product',
-                sku: 'p-299'
-              }
-            ]
-          });
-          analytics.called(window._qevents.push, {
-            event: 'refresh',
-            labels: 'order completed,_fp.pcat.Name.my product,_fp.pcat.ProductID.product_1,_fp.pcat.SKU.p-298,_fp.pcat.Name.other product,_fp.pcat.ProductID.product_2,_fp.pcat.SKU.p-299,_fp.pcat.Quantity.4',
-            orderid: '780bc55',
-            qacct: options.pCode,
-            revenue: '99.99'
-          });
-        });
-
         it('should set repeat property if present', function() {
           analytics.track('order completed', {
             orderId: '780bc55',
@@ -459,7 +426,7 @@ describe('Quantcast', function() {
           });
         });
 
-        it('should handle include products for order completed events', function() {
+        it('should not include products for order completed events', function() {
           quantcast.options.advertise = true;
           analytics.track('order completed', {
             orderId: '780bc55',
@@ -486,10 +453,47 @@ describe('Quantcast', function() {
           });
           analytics.called(window._qevents.push, {
             event: 'refresh',
-            labels: '_fp.event.order completed,_fp.pcat.tech,_fp.pcat.Name.my product,_fp.pcat.ProductID.product_1,_fp.pcat.SKU.p-298,_fp.pcat.Name.other product,_fp.pcat.ProductID.product_2,_fp.pcat.SKU.p-299,_fp.pcat.Quantity.4',
+            labels: '_fp.event.order completed,_fp.pcat.tech',
             orderid: '780bc55',
             qacct: options.pCode,
             revenue: '99.99'
+          });
+        });
+
+        describe('when advertiseProducts is true', function() {
+          it('should handle include products for order completed events', function() {
+            quantcast.options.advertise = true;
+            quantcast.options.advertiseProducts = true;
+            analytics.track('order completed', {
+              orderId: '780bc55',
+              category: 'tech',
+              total: 99.99,
+              shipping: 13.99,
+              tax: 20.99,
+              products: [
+                {
+                  productId: 'product_1',
+                  quantity: 1,
+                  price: 24.75,
+                  name: 'my product',
+                  sku: 'p-298'
+                },
+                {
+                  productId: 'product_2',
+                  quantity: 3,
+                  price: 24.75,
+                  name: 'other product',
+                  sku: 'p-299'
+                }
+              ]
+            });
+            analytics.called(window._qevents.push, {
+              event: 'refresh',
+              labels: '_fp.event.order completed,_fp.pcat.tech,_fp.pcat.Name.my product,_fp.pcat.ProductID.product_1,_fp.pcat.SKU.p-298,_fp.pcat.Name.other product,_fp.pcat.ProductID.product_2,_fp.pcat.SKU.p-299,_fp.pcat.Quantity.4',
+              orderid: '780bc55',
+              qacct: options.pCode,
+              revenue: '99.99'
+            });
           });
         });
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -368,7 +368,7 @@ describe('Quantcast', function() {
           });
           analytics.called(window._qevents.push, {
             event: 'refresh',
-            labels: 'order completed,_fp.pcat.ProductID=product_1,_fp.pcat.SKU=p-298,_fp.pcat.Name=my product,_fp.pcat.Price=24.75,_fp.pcat.Quantity=1,_fp.pcat.ProductID=product_2,_fp.pcat.SKU=p-299,_fp.pcat.Name=other product,_fp.pcat.Price=24.75,_fp.pcat.Quantity=3',
+            labels: 'order completed,_fp.pcat.Name.my product,_fp.pcat.ProductID.product_1,_fp.pcat.SKU.p-298,_fp.pcat.Name.other product,_fp.pcat.ProductID.product_2,_fp.pcat.SKU.p-299,_fp.pcat.Quantity.4',
             orderid: '780bc55',
             qacct: options.pCode,
             revenue: '99.99'
@@ -486,7 +486,7 @@ describe('Quantcast', function() {
           });
           analytics.called(window._qevents.push, {
             event: 'refresh',
-            labels: '_fp.event.order completed,_fp.pcat.tech,_fp.pcat.ProductID=product_1,_fp.pcat.SKU=p-298,_fp.pcat.Name=my product,_fp.pcat.Price=24.75,_fp.pcat.Quantity=1,_fp.pcat.ProductID=product_2,_fp.pcat.SKU=p-299,_fp.pcat.Name=other product,_fp.pcat.Price=24.75,_fp.pcat.Quantity=3',
+            labels: '_fp.event.order completed,_fp.pcat.tech,_fp.pcat.Name.my product,_fp.pcat.ProductID.product_1,_fp.pcat.SKU.p-298,_fp.pcat.Name.other product,_fp.pcat.ProductID.product_2,_fp.pcat.SKU.p-299,_fp.pcat.Quantity.4',
             orderid: '780bc55',
             qacct: options.pCode,
             revenue: '99.99'


### PR DESCRIPTION
[PLATFORM-1462](https://segment.atlassian.net/browse/PLATFORM-1462) ([comment](https://segment.atlassian.net/browse/PLATFORM-1462?focusedCommentId=42558&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-42558))

This PR makes a few changes on behalf of the Quantcast team:
 - use `.` instead of `=` as a delimiter for key/value labels
 - remove price labels
 - compute quantity as a single label for all products in the list

There is 1 last request they've made, which I will consult with @emiliogomezlavin and the Quantcast team before we merge and deploy this. They requested a new flag to hide these new labels, but I am wondering if we should just leverage the existing `options.advertise` flag instead of adding a new one.